### PR TITLE
fix MSWin32 .latest symlink errors

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/Author/ETHER.pm
+++ b/lib/Dist/Zilla/PluginBundle/Author/ETHER.pm
@@ -322,7 +322,9 @@ sub configure
         ( $self->_has_bash ?
             [ 'Run::AfterBuild' => '.ackrc' => { ':version' => '0.038', quiet => 1, run => q{bash -c "test -e .ackrc && grep -q -- '--ignore-dir=.latest' .ackrc || echo '--ignore-dir=.latest' >> .ackrc; if [[ `dirname '%d'` != .build ]]; then test -e .ackrc && grep -q -- '--ignore-dir=%d' .ackrc || echo '--ignore-dir=%d' >> .ackrc; fi"} } ]
             : ()),
-        [ 'Run::AfterBuild'     => '.latest' => { ':version' => '0.038', quiet => 1, eval => q!if ('%d' =~ /^%n-[.[:xdigit:]]+$/) { unlink '.latest'; symlink '%d', '.latest'; }! } ],
+        ( $self->_has_bash ?
+            [ 'Run::AfterBuild'     => '.latest' => { ':version' => '0.038', quiet => 1, eval => q!if ('%d' =~ /^%n-[.[:xdigit:]]+$/) { unlink '.latest'; symlink '%d', '.latest'; }! } ]
+            : ()),
 
 
         # Before Release


### PR DESCRIPTION
Using this bundle, `dzil build` (on MSWin32 machines, under `CMD`),  generates a fatal exception when trying to create a .latest symlink. 

```
[@Author::ETHER/.latest] evaluated: if ('Dist-Zilla-Plugin-Run-0.044' =~ /^Dist-Zilla-Plugin-Run-[.[:xdigit:]]+$/) { unlink '.latest'; symlink 'Dist-Zilla-Plugin-Run-0.044', '.latest'; }
[@Author::ETHER/.latest] evaluation died: The symlink function is unimplemented at (eval 2550) line 1.

[@Author::ETHER/.latest] evaluation died: The symlink function is unimplemented at (eval 2550) line 1.
 at C:/Users/Roy/AppData/Local/scoop/apps/perl/5.20.1.1/perl/vendor/lib/Moose/Meta/Method/Delegation.pm line 112.
```

An early "missing bash" warning message implies that this should be gated to _has_bash() in a similar manner to .ackrc creation. That implementation is used in this PR.