### PR TITLE
add color support for MSWin32 platforms

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/Author/ETHER.pm
+++ b/lib/Dist/Zilla/PluginBundle/Author/ETHER.pm
@@ -21,6 +21,7 @@ use Devel::CheckBin 'can_run';
 use Path::Tiny;
 use CPAN::Meta::Requirements;
 use Term::ANSIColor 'colored';
+eval 'require Win32::Console::ANSI' if $^O eq 'MSWin32';
 use namespace::autoclean;
 
 sub mvp_multivalue_args { qw(installer copy_file_from_release) }


### PR DESCRIPTION
This is a simple addition that activates color output on 'MSWin32' platforms.

No other code changes are needed.

I can refactor the line if you'd like it to appear differently. It's current, somewhat stilted, form is Perl::Critic friendly.

Notably, this is a optional dependency which can leave an opening for [". in @INC"](https://dzone.com/articles/security-separation-of-concerns-and-cve-2016-1238)<sup>[[@@](https://archive.is/sKbcs)]</sup> module injection. Hence, the OS platform comparison which limits the exposure to only 'MSWin32' platforms. It can be made even more secure by using ...

```
() = eval { local @INC = grep !/^\.$/, @INC; require Win32::Console::ANSI } if 'MSWin32' eq $^O;
```

But that might be overly paranoid. :smile: 

For further context, see my discussion with @kentnl at [Dist-Zilla-...-RecommendFixes/GH/PR#1](https://github.com/kentnl/Dist-Zilla-Plugin-Author-KENTNL-RecommendFixes/pull/1).
